### PR TITLE
implements: favourite & unfavourite articles

### DIFF
--- a/src/articles/articles.controller.ts
+++ b/src/articles/articles.controller.ts
@@ -55,4 +55,20 @@ export class ArticlesController {
   ): Promise<void> {
     await this.articlesService.deleteArticle(slug, user.id);
   }
+
+  @Post(':slug/favorite')
+  async favoriteArticle(
+    @Param('slug') slug: string,
+    @CurrentUser() currentUser: User,
+  ): Promise<ArticleResponseDto> {
+    return this.articlesService.favoriteArticle(slug, currentUser);
+  }
+
+  @Delete(':slug/favorite')
+  async unfavoriteArticle(
+    @Param('slug') slug: string,
+    @CurrentUser() currentUser: User,
+  ): Promise<ArticleResponseDto> {
+    return this.articlesService.unfavoriteArticle(slug, currentUser);
+  }
 }


### PR DESCRIPTION
Changes/ Additions:

ArticlesController:
POST /api/articles/:slug/favorite
 → Favorite một bài viết theo slug (yêu cầu token). 
DELETE /api/articles/:slug/favorite
 → Unfavorite bài viết theo slug (yêu cầu token). 

ArticlesService:
favoriteArticle(slug, currentUser)
 → Xử lý favorite bài viết, kiểm tra tồn tại của bài viết và tránh duplicate favorite.
unfavoriteArticle(slug, currentUser)
 → Xử lý unfavorite bài viết, kiểm tra tồn tại của bài viết và đã favorite trước đó chưa.
Cả hai hàm đều fetch lại thông tin bài viết sau khi thao tác để trả về dữ liệu mới nhất (favorited, favoritesCount, author...).

Article-Response-Dto và Build-Article-Response được tái sử dụng từ feature/crud-articles trước đó